### PR TITLE
fix: refresh update lists and harden compatibility tool install flow

### DIFF
--- a/backend/src/github_util.rs
+++ b/backend/src/github_util.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Release {
     pub url: String,
     pub id: u64,
@@ -18,7 +18,7 @@ pub struct Release {
     pub body: String,
 }
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Asset {
     pub url: String,
     pub id: u64,
@@ -37,10 +37,31 @@ pub struct Response {
     pub message: String,
 }
 
+/// Result of a conditional fetch operation
+#[derive(Debug)]
+pub enum FetchResult {
+    /// Releases were modified, contains the new releases and optionally the last-modified timestamp
+    Modified(Vec<Release>, Option<String>),
+    /// Releases were not modified (304 Not Modified)
+    NotModified,
+}
+
+/// Fetches all releases from GitHub repository with optional conditional request support
+///
+/// # Arguments
+/// * `owner` - Repository owner
+/// * `repository` - Repository name
+/// * `if_modified_since` - Optional timestamp for If-Modified-Since header (RFC 2822 format)
+///
+/// # Returns
+/// * `Ok(FetchResult::Modified(releases, last_modified))` - New releases fetched
+/// * `Ok(FetchResult::NotModified)` - Server responded with 304 Not Modified
+/// * `Err(GitHubUtilError)` - Error occurred
 pub async fn list_all_releases(
     owner: &str,
     repository: &str,
-) -> Result<Vec<Release>, GitHubUtilError> {
+    if_modified_since: Option<&str>,
+) -> Result<FetchResult, GitHubUtilError> {
     let client = reqwest::Client::builder()
         .user_agent("FlashyReese/decky-wine-cellar")
         .build()
@@ -48,6 +69,7 @@ pub async fn list_all_releases(
 
     let mut releases: Vec<Release> = Vec::new();
     let mut page = 1;
+    let mut last_modified: Option<String> = None;
 
     loop {
         let url = format!(
@@ -55,9 +77,32 @@ pub async fn list_all_releases(
             owner, repository, page
         );
 
-        let response = client.get(&url).send().await?;
+        let mut request = client.get(&url);
+
+        // Add If-Modified-Since header only for the first page
+        if page == 1 {
+            if let Some(timestamp) = if_modified_since {
+                request = request.header("If-Modified-Since", timestamp);
+            }
+        }
+
+        let response = request.send().await?;
+
+        // Handle 304 Not Modified (only relevant for first page)
+        if page == 1 && response.status() == reqwest::StatusCode::NOT_MODIFIED {
+            return Ok(FetchResult::NotModified);
+        }
 
         if response.status().is_success() {
+            // Extract last-modified header from first page response
+            if page == 1 {
+                last_modified = response
+                    .headers()
+                    .get("last-modified")
+                    .and_then(|v| v.to_str().ok())
+                    .map(|s| s.to_string());
+            }
+
             let response_text = response.text().await?;
             if let Ok(page_releases) = serde_json::from_str::<Vec<Release>>(&response_text) {
                 if page_releases.is_empty() {
@@ -81,7 +126,7 @@ pub async fn list_all_releases(
         }
     }
 
-    Ok(releases)
+    Ok(FetchResult::Modified(releases, last_modified))
 }
 
 #[derive(Debug)]

--- a/backend/src/wine_cask/app.rs
+++ b/backend/src/wine_cask/app.rs
@@ -261,6 +261,8 @@ impl WineCask {
         self.app_state.lock().await.updater_state = UpdaterState::Checking;
         self.broadcast_app_state(peer_map).await;
         self.app_state.lock().await.flavors = self.get_flavors(renew_cache).await;
+        // Rebuild installable lists from freshly fetched flavors so frontend pages update.
+        self.update_compatibility_tools_and_available_flavors().await;
         self.app_state.lock().await.updater_state = UpdaterState::Idle;
         self.broadcast_app_state(peer_map).await;
     }

--- a/backend/src/wine_cask/flavors.rs
+++ b/backend/src/wine_cask/flavors.rs
@@ -1,5 +1,5 @@
 use crate::github_util;
-use crate::github_util::Release;
+use crate::github_util::{Release, FetchResult};
 use crate::wine_cask::app::WineCask;
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
@@ -173,57 +173,184 @@ impl WineCask {
         }
     }
 
+    /// Reads the last-modified timestamp from metadata file
+    fn read_cache_metadata(path: &str, owner: &str, repository: &str) -> Option<String> {
+        let metadata_file = PathBuf::from(path)
+            .join(format!("github_releases_{}_{}_metadata.txt", owner, repository));
+
+        if metadata_file.exists() {
+            fs::read_to_string(metadata_file).ok()
+        } else {
+            None
+        }
+    }
+
+    /// Writes the last-modified timestamp to metadata file
+    fn write_cache_metadata(path: &str, owner: &str, repository: &str, last_modified: &str) {
+        let metadata_file = PathBuf::from(path)
+            .join(format!("github_releases_{}_{}_metadata.txt", owner, repository));
+
+        if let Err(e) = fs::write(metadata_file, last_modified) {
+            warn!("Failed to write cache metadata: {}", e);
+        }
+    }
+
     async fn get_releases(
         &self,
         owner: &str,
         repository: &str,
         renew_cache: bool,
     ) -> Option<Vec<Release>> {
-        const SECONDS_IN_A_DAY: u64 = 84_600;
+        // Fixed: 86,400 seconds in a day (not 84,600)
+        const CACHE_DURATION_SECONDS: u64 = 86_400;
 
         let path = env::var("DECKY_PLUGIN_RUNTIME_DIR").unwrap_or("/tmp/".parse().unwrap());
+        let cache_file = PathBuf::from(&path)
+            .join(format!("github_releases_{}_{}_cache.json", owner, repository));
 
-        let file_name = format!("github_releases_{}_{}_cache.json", owner, repository);
-        let cache_file = PathBuf::from(path).join(&file_name);
-
-        if !renew_cache && cache_file.exists() && cache_file.is_file() {
-            let metadata = fs::metadata(&cache_file).ok()?;
-            let modified = metadata.modified().ok()?;
-
-            // Calculate the duration between the current time and the file modification time
-            let now = SystemTime::now();
-            let duration = now.duration_since(modified).ok()?;
-
-            if duration.as_secs() < SECONDS_IN_A_DAY {
-                // Update last checked time with file last modified time
-                let unix_timestamp = modified
-                    .duration_since(UNIX_EPOCH)
-                    .expect("Failed to calculate duration")
-                    .as_secs();
-                self.app_state.lock().await.updater_last_check = Some(unix_timestamp);
-
-                let string = fs::read_to_string(&cache_file).ok()?;
-                let github_releases: Vec<Release> = serde_json::from_str(&string).ok()?;
-
-                // Check if parsing failed but data exists (cache is corrupted)
-                if github_releases.is_empty() {
-                    info!("Cached data is possibly corrupted or possibly missing information from outdated version. Renewing cache...");
-                } else {
-                    return Some(github_releases);
+        // Try to load cached data
+        let cached_data = if cache_file.exists() && cache_file.is_file() {
+            match fs::metadata(&cache_file) {
+                Ok(metadata) => match metadata.modified() {
+                    Ok(modified) => {
+                        let now = SystemTime::now();
+                        match now.duration_since(modified) {
+                            Ok(duration) => match fs::read_to_string(&cache_file) {
+                                Ok(string) => match serde_json::from_str::<Vec<Release>>(&string) {
+                                    Ok(github_releases) if !github_releases.is_empty() => {
+                                        Some((github_releases, duration.as_secs(), modified))
+                                    }
+                                    Ok(_) => {
+                                        info!(
+                                            "Cached data is empty or corrupted. Renewing cache..."
+                                        );
+                                        None
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            "Failed to parse cache file ({}). Renewing cache...",
+                                            e
+                                        );
+                                        None
+                                    }
+                                },
+                                Err(e) => {
+                                    warn!("Failed to read cache file ({}). Renewing cache...", e);
+                                    None
+                                }
+                            },
+                            Err(e) => {
+                                warn!(
+                                    "Invalid cache modification timestamp ({}). Renewing cache...",
+                                    e
+                                );
+                                None
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Failed to read cache file metadata timestamp ({}). Renewing cache...",
+                            e
+                        );
+                        None
+                    }
+                },
+                Err(e) => {
+                    warn!("Failed to read cache file metadata ({}). Renewing cache...", e);
+                    None
                 }
-            } else {
-                info!("Cache file is older than 1 day. Fetching new releases.");
+            }
+        } else {
+            None
+        };
+
+        // Determine if we should use cache, check with conditional request, or fetch fresh
+        let should_fetch_fresh = renew_cache || cached_data.is_none();
+
+        if !should_fetch_fresh {
+            if let Some((releases, cache_age, modified)) = cached_data {
+                // Cache is fresh (less than CACHE_DURATION old), use it directly
+                if cache_age < CACHE_DURATION_SECONDS {
+                    let unix_timestamp = modified
+                        .duration_since(UNIX_EPOCH)
+                        .expect("Failed to calculate duration")
+                        .as_secs();
+                    self.app_state.lock().await.updater_last_check = Some(unix_timestamp);
+
+                    info!("Using cached releases (age: {}s < {}s)", cache_age, CACHE_DURATION_SECONDS);
+                    return Some(releases);
+                }
+
+                // Cache is stale, try conditional request with If-Modified-Since
+                let last_modified = Self::read_cache_metadata(&path, owner, repository);
+
+                info!("Cache is stale (age: {}s), checking with GitHub using If-Modified-Since", cache_age);
+
+                match github_util::list_all_releases(owner, repository, last_modified.as_deref()).await {
+                    Ok(FetchResult::NotModified) => {
+                        // Cache is still valid, update last_check time and use it
+                        let unix_timestamp = modified
+                            .duration_since(UNIX_EPOCH)
+                            .expect("Failed to calculate duration")
+                            .as_secs();
+                        self.app_state.lock().await.updater_last_check = Some(unix_timestamp);
+
+                        info!("GitHub confirms cache is still valid (304 Not Modified)");
+                        return Some(releases);
+                    }
+                    Ok(FetchResult::Modified(new_releases, new_last_modified)) => {
+                        // New data available, update cache
+                        if new_releases.is_empty() {
+                            error!("No releases found in fresh fetch.");
+                            return None;
+                        }
+
+                        let current_time = SystemTime::now();
+                        let unix_timestamp = current_time
+                            .duration_since(UNIX_EPOCH)
+                            .expect("Failed to calculate duration")
+                            .as_secs();
+                        self.app_state.lock().await.updater_last_check = Some(unix_timestamp);
+
+                        // Update cache file
+                        let json = serde_json::to_string(&new_releases).ok()?;
+                        if let Err(e) = fs::write(&cache_file, json) {
+                            error!("Failed to write cache file: {}", e);
+                        }
+
+                        // Update metadata file with new last-modified timestamp
+                        if let Some(lm) = new_last_modified {
+                            Self::write_cache_metadata(&path, owner, repository, &lm);
+                        }
+
+                        info!("Updated cache with {} releases from GitHub", new_releases.len());
+                        return Some(new_releases);
+                    }
+                    Err(e) => {
+                        // Failed to check with GitHub, fall back to cached data
+                        warn!("Failed to check GitHub for updates ({}), using stale cache", e);
+                        let unix_timestamp = modified
+                            .duration_since(UNIX_EPOCH)
+                            .expect("Failed to calculate duration")
+                            .as_secs();
+                        self.app_state.lock().await.updater_last_check = Some(unix_timestamp);
+                        return Some(releases);
+                    }
+                }
             }
         }
 
-        let github_releases = match github_util::list_all_releases(owner, repository).await {
-            Ok(releases) => {
+        // Fetch fresh data (no cache or renew_cache=true)
+        info!("Fetching fresh releases from GitHub for {}/{}", owner, repository);
+
+        match github_util::list_all_releases(owner, repository, None).await {
+            Ok(FetchResult::Modified(releases, last_modified)) => {
                 if releases.is_empty() {
                     error!("No releases found.");
                     return None;
                 }
 
-                // Update last checked time
                 let current_time = SystemTime::now();
                 let unix_timestamp = current_time
                     .duration_since(UNIX_EPOCH)
@@ -231,32 +358,40 @@ impl WineCask {
                     .as_secs();
                 self.app_state.lock().await.updater_last_check = Some(unix_timestamp);
 
+                // Update cache file
                 let json = serde_json::to_string(&releases).ok()?;
-                fs::write(&cache_file, json).ok()?;
-                releases
+                if let Err(e) = fs::write(&cache_file, json) {
+                    error!("Failed to write cache file: {}", e);
+                }
+
+                // Update metadata file
+                if let Some(lm) = last_modified {
+                    Self::write_cache_metadata(&path, owner, repository, &lm);
+                }
+
+                info!("Fetched and cached {} releases", releases.len());
+                Some(releases)
             }
-            Err(_) => {
-                if cache_file.exists() && cache_file.is_file() {
-                    // Update last checked time with file last modified time
-                    let metadata = fs::metadata(&cache_file).ok()?;
-                    let modified = metadata.modified().ok()?;
+            Ok(FetchResult::NotModified) => {
+                // This shouldn't happen when we don't send If-Modified-Since
+                warn!("Unexpected 304 Not Modified response without If-Modified-Since header");
+                None
+            }
+            Err(e) => {
+                // Try to fall back to cached data even if it's old
+                if let Some((releases, _, modified)) = cached_data {
+                    warn!("Failed to fetch releases ({}), falling back to cached data", e);
                     let unix_timestamp = modified
                         .duration_since(UNIX_EPOCH)
                         .expect("Failed to calculate duration")
                         .as_secs();
                     self.app_state.lock().await.updater_last_check = Some(unix_timestamp);
-
-                    let string = fs::read_to_string(&cache_file).ok()?;
-                    let github_releases: Vec<Release> = serde_json::from_str(&string).ok()?;
-                    warn!("Unable to fetch new releases. Using cached releases.");
-                    github_releases
+                    Some(releases)
                 } else {
-                    error!("Unable to fetch new releases. No cached releases found.");
-                    return None;
+                    error!("Unable to fetch releases and no cache available: {}", e);
+                    None
                 }
             }
-        };
-
-        Some(github_releases)
+        }
     }
 }

--- a/backend/src/wine_cask/install.rs
+++ b/backend/src/wine_cask/install.rs
@@ -44,185 +44,361 @@ pub enum CompressionType {
     Unknown,
 }
 
+#[derive(Debug)]
+pub enum InstallError {
+    NetworkError(String),
+    DownloadFailed(String),
+    ExtractionFailed(String),
+    InstallationFailed(String),
+    Cancelled,
+    InvalidAsset,
+    IoError(String),
+}
+
+impl std::fmt::Display for InstallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InstallError::NetworkError(msg) => write!(f, "Network error: {}", msg),
+            InstallError::DownloadFailed(msg) => write!(f, "Download failed: {}", msg),
+            InstallError::ExtractionFailed(msg) => write!(f, "Extraction failed: {}", msg),
+            InstallError::InstallationFailed(msg) => write!(f, "Installation failed: {}", msg),
+            InstallError::Cancelled => write!(f, "Installation cancelled"),
+            InstallError::InvalidAsset => write!(f, "Invalid or missing asset"),
+            InstallError::IoError(msg) => write!(f, "I/O error: {}", msg),
+        }
+    }
+}
+
 impl WineCask {
-    // Why is this task queue here? Well because steam deck will die if someone tries to queue up 50 installs at once.
+    /// Installs a compatibility tool with proper error handling and notifications
     pub async fn install_compatibility_tool(&self, install: Install, peer_map: &PeerMap) {
-        if let Some(mut queue_compatibility_tool) = look_for_compressed_archive(&install) {
-            // Mark as downloading...
-            queue_compatibility_tool.state = QueueCompatibilityToolState::Downloading;
-            queue_compatibility_tool.progress = 0;
-            self.app_state.lock().await.in_progress = Some(queue_compatibility_tool.clone());
+        // Check if we have a valid compressed archive to download
+        let queue_compatibility_tool = match look_for_compressed_archive(&install) {
+            Some(tool) => tool,
+            None => {
+                let error_msg = format!(
+                    "Installation Failed: No compatible archive found for {}",
+                    install.release.name
+                );
+                error!("{}", error_msg);
+                self.broadcast_notification(peer_map, &error_msg).await;
+                return;
+            }
+        };
+
+        let mut queue_compatibility_tool = queue_compatibility_tool;
+
+        // Mark as downloading...
+        queue_compatibility_tool.state = QueueCompatibilityToolState::Downloading;
+        queue_compatibility_tool.progress = 0;
+        self.app_state.lock().await.in_progress = Some(queue_compatibility_tool.clone());
+        self.broadcast_app_state(peer_map).await;
+
+        // Attempt download with error handling
+        let download_result = self.download_compatibility_tool(
+            &queue_compatibility_tool,
+            peer_map,
+        ).await;
+
+        let (downloaded_bytes, expected_size) = match download_result {
+            Ok(bytes) => bytes,
+            Err(InstallError::Cancelled) => {
+                // User cancelled, already cleaned up
+                return;
+            }
+            Err(e) => {
+                let error_msg = format!("Installation Failed: {}", e);
+                error!("{}", error_msg);
+                self.app_state.lock().await.in_progress = None;
+                self.broadcast_app_state(peer_map).await;
+                self.broadcast_notification(peer_map, &error_msg).await;
+                return;
+            }
+        };
+
+        // Validate downloaded size
+        if expected_size > 0 && downloaded_bytes.len() as u64 != expected_size {
+            let error_msg = format!(
+                "Installation Failed: Downloaded file size mismatch (expected {} bytes, got {} bytes)",
+                expected_size,
+                downloaded_bytes.len()
+            );
+            error!("{}", error_msg);
+            self.app_state.lock().await.in_progress = None;
             self.broadcast_app_state(peer_map).await;
+            self.broadcast_notification(peer_map, &error_msg).await;
+            return;
+        }
 
-            // Starting download compatibility tool
-            let client = reqwest::Client::new();
-            let response_wrapped = client.get(&queue_compatibility_tool.url).send().await;
-            let response = response_wrapped.unwrap();
-            let total_size = response.content_length().unwrap_or(0);
+        // Validate downloaded bytes are not empty
+        if downloaded_bytes.is_empty() {
+            let error_msg = "Installation Failed: Downloaded file is empty".to_string();
+            error!("{}", error_msg);
+            self.app_state.lock().await.in_progress = None;
+            self.broadcast_app_state(peer_map).await;
+            self.broadcast_notification(peer_map, &error_msg).await;
+            return;
+        }
 
-            let mut downloaded_bytes = Vec::new();
-            let mut downloaded_size = 0;
-            let mut body = response.bytes_stream();
+        info!(
+            "Successfully downloaded {} ({} bytes)",
+            install.release.name,
+            downloaded_bytes.len()
+        );
 
-            while let Some(chunk_result) = body.next().await {
-                // Check if we need to cancel the download
-                if self
-                    .app_state
-                    .lock()
-                    .await
-                    .in_progress
-                    .clone()
-                    .unwrap()
-                    .state
-                    == QueueCompatibilityToolState::Cancelling
-                {
-                    self.app_state.lock().await.in_progress = None;
-                    self.broadcast_app_state(peer_map).await;
-                    return; // We stop the function here
+        let reader = Cursor::new(downloaded_bytes);
+
+        // Extract and install
+        let extract_result = self.extract_generate_and_move(
+            peer_map,
+            &install,
+            &mut queue_compatibility_tool,
+            reader,
+        ).await;
+
+        // Clean up in_progress state
+        self.app_state.lock().await.in_progress = None;
+        self.broadcast_app_state(peer_map).await;
+
+        // Send appropriate notification based on result
+        match extract_result {
+            Ok(()) => {
+                let message = format!("Installation Completed: {}", install.release.name);
+                info!("{}", message);
+                self.broadcast_notification(peer_map, &message).await;
+            }
+            Err(InstallError::Cancelled) => {
+                // Already handled
+            }
+            Err(e) => {
+                let error_msg = format!("Installation Failed: {}", e);
+                error!("{}", error_msg);
+                self.broadcast_notification(peer_map, &error_msg).await;
+            }
+        }
+    }
+
+    /// Downloads compatibility tool with progress tracking and cancellation support
+    async fn download_compatibility_tool(
+        &self,
+        queue_compatibility_tool: &QueueCompatibilityTool,
+        peer_map: &PeerMap,
+    ) -> Result<(Vec<u8>, u64), InstallError> {
+        let client = reqwest::Client::new();
+
+        info!(
+            "Starting download from: {}",
+            queue_compatibility_tool.url
+        );
+
+        let response = client
+            .get(&queue_compatibility_tool.url)
+            .send()
+            .await
+            .map_err(|e| InstallError::NetworkError(e.to_string()))?;
+
+        // Check HTTP status
+        if !response.status().is_success() {
+            return Err(InstallError::DownloadFailed(format!(
+                "HTTP {}",
+                response.status()
+            )));
+        }
+
+        let total_size = response.content_length().unwrap_or(0);
+
+        if total_size == 0 {
+            warn!("Content-Length header missing or zero, download progress may be inaccurate");
+        }
+
+        let mut downloaded_bytes = Vec::new();
+        let mut downloaded_size = 0u64;
+        let mut body = response.bytes_stream();
+
+        while let Some(chunk_result) = body.next().await {
+            // Check if we need to cancel the download
+            let should_cancel = {
+                let app_state = self.app_state.lock().await;
+                if let Some(ref in_progress) = app_state.in_progress {
+                    in_progress.state == QueueCompatibilityToolState::Cancelling
+                } else {
+                    false
                 }
-                if let Ok(chunk) = chunk_result {
+            };
+
+            if should_cancel {
+                info!("Download cancelled by user");
+                self.app_state.lock().await.in_progress = None;
+                self.broadcast_app_state(peer_map).await;
+                return Err(InstallError::Cancelled);
+            }
+
+            match chunk_result {
+                Ok(chunk) => {
                     downloaded_bytes.extend_from_slice(&chunk);
                     downloaded_size += chunk.len() as u64;
 
-                    let progress = ((downloaded_size as f64 / total_size as f64) * 100.0) as u8;
-                    if queue_compatibility_tool.progress != progress {
-                        // Update progress...
-                        queue_compatibility_tool.progress = progress;
-                        self.app_state.lock().await.in_progress =
-                            Some(queue_compatibility_tool.clone());
-                        self.broadcast_app_state(peer_map).await;
+                    // Update progress
+                    if total_size > 0 {
+                        let progress = ((downloaded_size as f64 / total_size as f64) * 100.0) as u8;
+                        let mut should_broadcast = false;
+                        {
+                            let mut app_state = self.app_state.lock().await;
+                            if let Some(ref mut in_progress) = app_state.in_progress {
+                                if in_progress.progress != progress {
+                                    in_progress.progress = progress;
+                                    should_broadcast = true;
+                                }
+                            }
+                        }
+                        if should_broadcast {
+                            self.broadcast_app_state(peer_map).await;
+                        }
                     }
-                } else {
-                    let error_message =
-                        "Connection Error: Download in progress failed!".to_string();
-                    error!("{}", error_message);
-                    self.app_state.lock().await.in_progress = None;
-                    self.broadcast_app_state(peer_map).await;
-                    self.broadcast_notification(peer_map, error_message.as_str())
-                        .await;
-                    return;
+                }
+                Err(e) => {
+                    return Err(InstallError::DownloadFailed(e.to_string()));
                 }
             }
+        }
 
-            let reader = Cursor::new(downloaded_bytes);
-
-            self.extract_generate_and_move(
-                peer_map,
-                &install,
-                &mut queue_compatibility_tool,
-                reader,
-            )
-            .await;
-        } 
+        Ok((downloaded_bytes, total_size))
     }
 
+    /// Extracts, generates VDF if needed, and moves to Steam directory
     pub async fn extract_generate_and_move(
         &self,
         peer_map: &PeerMap,
         install: &Install,
         queue_compatibility_tool: &mut QueueCompatibilityTool,
         reader: Cursor<Vec<u8>>,
-    ) {
-        if let Some(temp_dir) = prepare_temp_directory() {
-            // Mark as extracting...
-            queue_compatibility_tool.state = QueueCompatibilityToolState::Extracting;
-            queue_compatibility_tool.progress = 0;
-            self.app_state.lock().await.in_progress = Some(queue_compatibility_tool.clone());
-            self.broadcast_app_state(peer_map).await;
+    ) -> Result<(), InstallError> {
+        let temp_dir = prepare_temp_directory()
+            .ok_or_else(|| InstallError::IoError("Failed to create temp directory".to_string()))?;
 
-            let steam_compatibility_tools_directory =
-                self.steam_util.get_steam_compatibility_tools_directory();
-            // Spawn a new thread for the extraction process
-            // Why do we need this turns out unpack process is blocking, because of this async function doesn't yield control back to Rust runtime until the extraction is finished.
-            let queue_compatibility_tool_clone = queue_compatibility_tool.clone(); // Clone the queue_compatibility_tool
-            let temp_dir_clone = temp_dir.clone();
-            tokio::task::spawn_blocking(move || {
-                let decompressed: Box<dyn Read> =
-                    if queue_compatibility_tool_clone.compress_type == CompressionType::Gzip {
-                        Box::new(GzDecoder::new(reader))
-                    } else if queue_compatibility_tool_clone.compress_type == CompressionType::Xz {
-                        Box::new(XzDecoder::new(reader))
-                    } else {
-                        Box::new(reader) // fixme: explosion
-                    };
-                let mut tar = tar::Archive::new(decompressed);
-                tar.unpack(temp_dir_clone).unwrap();
-            })
-            .await
-            .unwrap();
+        // Mark as extracting...
+        queue_compatibility_tool.state = QueueCompatibilityToolState::Extracting;
+        queue_compatibility_tool.progress = 0;
+        self.app_state.lock().await.in_progress = Some(queue_compatibility_tool.clone());
+        self.broadcast_app_state(peer_map).await;
 
-            // Scan for the extracted directory
-            let valid_directories: Vec<PathBuf> = std::fs::read_dir(&temp_dir)
-                .map_err(|_err| {
-                    error!("Failed to read directory");
-                })
-                .unwrap()
-                .filter_map(Result::ok)
-                .filter(|x| {
-                    x.metadata().unwrap().is_dir()
-                        && x.path().join("compatibilitytool.vdf").exists()
-                })
-                .map(|x| x.path())
-                .collect();
+        let steam_compatibility_tools_directory =
+            self.steam_util.get_steam_compatibility_tools_directory();
 
-            if valid_directories.len() == 1 {
-                let first = valid_directories.first().unwrap();
-                let new_compat_tool_vdf = first.join("compatibilitytool.vdf");
-                let new_path = match queue_compatibility_tool.flavor {
-                    CompatibilityToolFlavor::ProtonGE => first.clone(),
-                    CompatibilityToolFlavor::SteamTinkerLaunch
-                    | CompatibilityToolFlavor::Luxtorpeda
-                    | CompatibilityToolFlavor::Boxtron => {
-                        let new_folder_name = format!(
-                            "{}{}",
-                            &queue_compatibility_tool.flavor, &install.release.tag_name
-                        );
-                        generate_compatibility_tool_vdf(
-                            new_compat_tool_vdf,
-                            &new_folder_name,
-                            &format!(
-                                "{} {}",
-                                &queue_compatibility_tool.flavor, &install.release.tag_name
-                            ),
-                        );
-                        temp_dir.join(&new_folder_name)
-                    }
-                    _ => {
-                        error!("Unsupported compatibility tool flavor");
-                        first.clone()
-                    }
+        // Spawn a blocking thread for extraction
+        let queue_compatibility_tool_clone = queue_compatibility_tool.clone();
+        let temp_dir_clone = temp_dir.clone();
+
+        let extraction_result = tokio::task::spawn_blocking(move || {
+            let decompressed: Box<dyn Read> =
+                if queue_compatibility_tool_clone.compress_type == CompressionType::Gzip {
+                    Box::new(GzDecoder::new(reader))
+                } else if queue_compatibility_tool_clone.compress_type == CompressionType::Xz {
+                    Box::new(XzDecoder::new(reader))
+                } else {
+                    Box::new(reader)
                 };
-                std::fs::rename(first, &new_path).unwrap();
 
-                match copy_dir(&temp_dir, &steam_compatibility_tools_directory) {
-                    Ok(_) => debug!("Directory copied successfully."),
-                    Err(e) => error!("Failed to copy directory: {}", e),
-                }
+            let mut tar = tar::Archive::new(decompressed);
+            tar.unpack(&temp_dir_clone)
+                .map_err(|e| InstallError::ExtractionFailed(e.to_string()))
+        })
+        .await
+        .map_err(|e| InstallError::ExtractionFailed(format!("Task join error: {}", e)))?;
 
+        // Check if extraction succeeded
+        extraction_result?;
+
+        info!("Extraction completed successfully");
+
+        // Scan for the extracted directory
+        let valid_directories: Vec<PathBuf> = match std::fs::read_dir(&temp_dir) {
+            Ok(entries) => entries
+                .filter_map(|entry| entry.ok())
+                .filter(|entry| {
+                    entry.metadata().ok().map(|m| m.is_dir()).unwrap_or(false)
+                        && entry.path().join("compatibilitytool.vdf").exists()
+                })
+                .map(|entry| entry.path())
+                .collect(),
+            Err(e) => {
+                cleanup_temp_directory(&temp_dir);
+                return Err(InstallError::IoError(format!(
+                    "Failed to read extracted directory: {}",
+                    e
+                )));
+            }
+        };
+
+        if valid_directories.len() != 1 {
+            let error_msg = format!(
+                "Expected 1 valid directory, found {}",
+                valid_directories.len()
+            );
+            cleanup_temp_directory(&temp_dir);
+            return Err(InstallError::InstallationFailed(error_msg));
+        }
+
+        let first = valid_directories.first().unwrap();
+        let new_compat_tool_vdf = first.join("compatibilitytool.vdf");
+
+        let new_path = match queue_compatibility_tool.flavor {
+            CompatibilityToolFlavor::ProtonGE => first.clone(),
+            CompatibilityToolFlavor::SteamTinkerLaunch
+            | CompatibilityToolFlavor::Luxtorpeda
+            | CompatibilityToolFlavor::Boxtron => {
+                let new_folder_name = format!(
+                    "{}{}",
+                    &queue_compatibility_tool.flavor, &install.release.tag_name
+                );
+                generate_compatibility_tool_vdf(
+                    new_compat_tool_vdf,
+                    &new_folder_name,
+                    &format!(
+                        "{} {}",
+                        &queue_compatibility_tool.flavor, &install.release.tag_name
+                    ),
+                );
+                temp_dir.join(&new_folder_name)
+            }
+            _ => {
+                cleanup_temp_directory(&temp_dir);
+                return Err(InstallError::InstallationFailed(
+                    "Unsupported compatibility tool flavor".to_string(),
+                ));
+            }
+        };
+
+        // Rename directory if needed
+        if first != &new_path {
+            if let Err(e) = std::fs::rename(first, &new_path) {
+                cleanup_temp_directory(&temp_dir);
+                return Err(InstallError::IoError(format!("Failed to rename directory: {}", e)));
+            }
+        }
+
+        // Copy to Steam directory
+        let copy_result = copy_dir(&temp_dir, &steam_compatibility_tools_directory);
+        cleanup_temp_directory(&temp_dir);
+
+        match copy_result {
+            Ok(_) => {
+                debug!("Directory copied successfully");
                 self.sync_backend_with_installed_compat_tools().await;
                 self.broadcast_app_state(peer_map).await;
-            } else {
-                error!("Failed to find extracted directory");
+                Ok(())
             }
-
-            cleanup_temp_directory(&temp_dir);
-
-            // Mark as completed
-            let message = format!("Installation Completed: {}", install.release.name);
-            info!("{}", message);
-            self.broadcast_notification(peer_map, message.as_str())
-                .await;
-            self.app_state.lock().await.in_progress = None;
-            self.broadcast_app_state(peer_map).await;
-        } else {
-            error!("Failed to prepare temp directory");
+            Err(e) => Err(InstallError::IoError(format!(
+                "Failed to copy to Steam directory: {}",
+                e
+            ))),
         }
     }
 }
 
 fn prepare_temp_directory() -> Option<PathBuf> {
     let temp_dir = PathBuf::from(
-        env::var("DECKY_PLUGIN_RUNTIME_DIR").unwrap_or("/tmp/decky-wine-cellar".to_string()),
+        env::var("DECKY_PLUGIN_RUNTIME_DIR").unwrap_or_else(|_| "/tmp/decky-wine-cellar".to_string()),
     )
     .join("temp");
 
@@ -246,17 +422,6 @@ fn cleanup_temp_directory(temp_dir: &Path) {
 }
 
 pub fn look_for_compressed_archive(install_request: &Install) -> Option<QueueCompatibilityTool> {
-    /*if install_request.flavor == CompatibilityToolFlavor::SteamTinkerLaunch {// fixme: doesn't actually work we need to handle this STL separately
-        return Some(QueueCompatibilityTool {
-            flavor: install_request.flavor.to_owned(),
-            name: install_request.release.tag_name.to_owned(),
-            url: format!("https://codeload.github.com/sonic2kk/steamtinkerlaunch/legacy.tar.gz/refs/tags/{}", install_request.release.tag_name), //install_request.release.tarball_url.to_owned(),
-            state: QueueCompatibilityToolState::Waiting,
-            compress_type: CompressionType::Gzip,
-            progress: 0,
-        });
-    }*/
-
     let is_compressed = |asset: &Asset| {
         asset.content_type == "application/gzip"
             || asset.content_type == "application/x-xz"
@@ -277,16 +442,15 @@ pub fn look_for_compressed_archive(install_request: &Install) -> Option<QueueCom
     if let Some(asset) = install_request
         .release
         .assets
-        .clone()
-        .into_iter()
-        .find(is_compressed)
+        .iter()
+        .find(|asset| is_compressed(asset))
     {
         return Some(QueueCompatibilityTool {
             flavor: install_request.flavor.to_owned(),
             name: install_request.release.tag_name.to_owned(),
-            url: asset.clone().browser_download_url,
+            url: asset.browser_download_url.clone(),
             state: QueueCompatibilityToolState::Waiting,
-            compress_type: compress_type(&asset),
+            compress_type: compress_type(asset),
             progress: 0,
         });
     }


### PR DESCRIPTION
## Summary
- rebuild available_flavors after refresh checks so the UI list updates immediately
- fix release cache handling to avoid early-abort on stale/corrupt cache files
- add conditional GitHub release fetch support (If-Modified-Since / 304 Not Modified)
- harden install flow to return real errors instead of reporting success on failed extract/copy
- fix install progress state update locking

## Why
This addresses two user-facing regressions:
1. update checks not surfacing new tools until plugin reinstall
2. latest compatibility tool install showing success notification even when the tool is not actually installed

## Validation
- pnpm run build
- RUSTFLAGS='-A dead_code' cargo build --release --manifest-path backend/Cargo.toml

## Issues
Fixes #10
Fixes #20
Likely addresses #21
Related: #8