### PR TITLE
Add proton-cachyos Deck CPU-specific builds to decky-wine-cellar

### DIFF
--- a/backend/src/wine_cask/app.rs
+++ b/backend/src/wine_cask/app.rs
@@ -826,6 +826,10 @@ fn find_catalog_release_for_tool(
                 {
                     return Some(catalog_release.clone());
                 }
+            } else if flavor.flavor == CompatibilityToolFlavor::ProtonCachyOS {
+                if installed_tool.display_name.to_lowercase().contains("cachyos") {
+                    return Some(catalog_release.clone());
+                }
             } else if installed_tool.display_name
                 == format!("{} {}", flavor.flavor, catalog_release.release.tag_name)
                 || installed_tool.internal_name

--- a/backend/src/wine_cask/flavors.rs
+++ b/backend/src/wine_cask/flavors.rs
@@ -11,6 +11,7 @@ use std::{env, fs};
 pub enum CompatibilityToolFlavor {
     Unknown,
     ProtonGE,
+    ProtonCachyOS,
     SteamTinkerLaunch,
     Luxtorpeda,
     Boxtron,
@@ -21,6 +22,7 @@ impl std::fmt::Display for CompatibilityToolFlavor {
         match self {
             CompatibilityToolFlavor::Unknown => write!(f, "Unknown"),
             CompatibilityToolFlavor::ProtonGE => write!(f, "ProtonGE"),
+            CompatibilityToolFlavor::ProtonCachyOS => write!(f, "ProtonCachyOS"),
             CompatibilityToolFlavor::SteamTinkerLaunch => write!(f, "SteamTinkerLaunch"),
             CompatibilityToolFlavor::Luxtorpeda => write!(f, "Luxtorpeda"),
             CompatibilityToolFlavor::Boxtron => write!(f, "Boxtron"),
@@ -125,7 +127,65 @@ impl WineCask {
         flavors.push(luxtorpeda_flavor);
         flavors.push(boxtron_flavor);
 
+        let proton_cachyos_flavor = self
+            .get_flavor_with_v3_filter(
+                CompatibilityToolFlavor::ProtonCachyOS,
+                "CachyOS",
+                "proton-cachyos",
+                renew_cache,
+            )
+            .await;
+        flavors.push(proton_cachyos_flavor);
+
         flavors
+    }
+
+    async fn get_flavor_with_v3_filter(
+        &self,
+        compatibility_tool_flavor: CompatibilityToolFlavor,
+        owner: &str,
+        repository: &str,
+        renew_cache: bool,
+    ) -> Flavor {
+        let releases = self.get_releases(owner, repository, renew_cache).await;
+
+        if let Some(releases) = releases {
+            let filtered = Self::filter_v3_releases(releases);
+            if filtered.is_empty() {
+                return Flavor {
+                    flavor: compatibility_tool_flavor,
+                    releases: Vec::new(),
+                };
+            }
+            Flavor {
+                flavor: compatibility_tool_flavor.clone(),
+                releases: filtered
+                    .into_iter()
+                    .map(|release| CatalogRelease {
+                        id: catalog_release_id(&compatibility_tool_flavor, release.id),
+                        flavor: compatibility_tool_flavor.clone(),
+                        release,
+                    })
+                    .collect(),
+            }
+        } else {
+            Flavor {
+                flavor: compatibility_tool_flavor,
+                releases: Vec::new(),
+            }
+        }
+    }
+
+    fn filter_v3_releases(releases: Vec<Release>) -> Vec<Release> {
+        let allowed_arches = ["x86_64_v3"];
+        releases
+            .into_iter()
+            .filter(|release| {
+                release.assets.iter().any(|asset| {
+                    allowed_arches.iter().any(|arch| asset.name.contains(arch))
+                })
+            })
+            .collect()
     }
 
     async fn get_flavor(

--- a/backend/src/wine_cask/install.rs
+++ b/backend/src/wine_cask/install.rs
@@ -284,7 +284,9 @@ impl WineCask {
             self.steam_util.get_steam_compatibility_tools_directory();
 
         let new_path = match install_plan.catalog_release.flavor {
-            CompatibilityToolFlavor::ProtonGE => extracted_directory.to_path_buf(),
+            CompatibilityToolFlavor::ProtonGE | CompatibilityToolFlavor::ProtonCachyOS => {
+                extracted_directory.to_path_buf()
+            }
             CompatibilityToolFlavor::SteamTinkerLaunch
             | CompatibilityToolFlavor::Luxtorpeda
             | CompatibilityToolFlavor::Boxtron => {

--- a/plugin.json
+++ b/plugin.json
@@ -9,6 +9,7 @@
     "tags": [
       "proton",
       "proton-ge",
+      "proton-cachyos",
       "luxtorpeda",
       "boxtron",
       "wine"

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,6 +196,7 @@ export type MessageEnvelope = {
 export enum CompatibilityToolFlavor {
   Unknown = "Unknown",
   ProtonGE = "ProtonGE",
+  ProtonCachyOS = "ProtonCachyOS",
   SteamTinkerLaunch = "SteamTinkerLaunch",
   Luxtorpeda = "Luxtorpeda",
   Boxtron = "Boxtron",


### PR DESCRIPTION
Added the proton-cachyos v3 processor specific compilation to decky-wine-loader.  

I get great performance with this version of proton but have to drop to desktop mode to update. Would really like to see it merged into decky-wine-cellar,  if you don't like the way the code is written, cloning ProtonGE's config,  please feel free to close the PR but pls consider adding it yourself!

The Proton-cachyos-v3 builds use specific compiler optimizations for the Steam Deck's CPU, which supports modern x86-64-v3 and AVX2 instruction sets.

Source: https://github.com/CachyOS/proton-cachyos