### PR TITLE
Update to help with reported memory bloating issue #25

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0.149"
 tar = "0.4.45"
 flate2 = "1.1.9"
 xz2 = "0.1.7"
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -141,6 +141,7 @@ async fn handle_connection(
 
     info!("{} disconnected", &addr);
     peer_map.lock().await.remove(&addr);
+    wine_cask.reclaim_memory_if_idle(&peer_map).await;
 }
 
 fn configure_logger() -> Result<(), IoError> {
@@ -211,7 +212,15 @@ async fn handle_request(wine_cask: &Arc<WineCask>, msg: &str, peer_map: &PeerMap
 
     match request.r#type {
         MessageType::GetState => {
-            wine_cask.broadcast_app_state(peer_map).await;
+            let needs_reload = {
+                let app_state = wine_cask.app_state.lock().await;
+                app_state.catalog_flavors.is_empty()
+            };
+            if needs_reload {
+                wine_cask.check_for_flavor_updates(peer_map, false).await;
+            } else {
+                wine_cask.broadcast_app_state(peer_map).await;
+            }
         }
         MessageType::ReportSteamVisibleTools => {
             if let Some(steam_visible_tools) = request.steam_visible_tools {

--- a/backend/src/wine_cask/app.rs
+++ b/backend/src/wine_cask/app.rs
@@ -761,6 +761,16 @@ impl WineCask {
     }
 
     pub async fn get_catalog_release(&self, release_id: &str) -> Option<CatalogRelease> {
+        let is_empty = {
+            let app_state = self.app_state.lock().await;
+            app_state.catalog_flavors.is_empty()
+        };
+        if is_empty {
+            let flavors = self.get_flavors(false).await;
+            let mut app_state = self.app_state.lock().await;
+            app_state.catalog_flavors = flavors;
+        }
+
         self.app_state
             .lock()
             .await
@@ -769,6 +779,34 @@ impl WineCask {
             .flat_map(|flavor| flavor.releases.iter())
             .find(|release| release.id == release_id)
             .cloned()
+    }
+
+    pub async fn reclaim_memory_if_idle(&self, peer_map: &PeerMap) {
+        let is_empty = peer_map.lock().await.is_empty();
+        if is_empty {
+            let can_clear = {
+                let app_state = self.app_state.lock().await;
+                app_state.current_operation.is_none() && app_state.operation_queue.is_empty()
+            };
+            if can_clear {
+                info!("All clients disconnected and no active operations. Clearing catalog flavors.");
+                let mut app_state = self.app_state.lock().await;
+                app_state.catalog_flavors.clear();
+                drop(app_state);
+
+                let mut cache = self.operation_broadcast_cache.lock().await;
+                *cache = None;
+                drop(cache);
+            }
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            info!("Calling malloc_trim to release memory to OS");
+            unsafe {
+                libc::malloc_trim(0);
+            }
+        }
     }
 
     pub async fn get_installed_tool(

--- a/backend/src/wine_cask/mod.rs
+++ b/backend/src/wine_cask/mod.rs
@@ -121,6 +121,7 @@ pub async fn process_queue(wine_cask: Arc<WineCask>, peer_map: PeerMap) {
             }
 
             wine_cask.complete_current_operation(&peer_map).await;
+            wine_cask.reclaim_memory_if_idle(&peer_map).await;
             continue;
         }
 


### PR DESCRIPTION
Help resolve memory bloat issues reported in Issue #25

When the Decky interface is closed, the backend will release its catalog data and trim memory, keeping its idle memory footprint around 20mb instead of potentially (much larger)

In app.rs, call libc::malloc_trim(0) to force the glibc allocator to immediately return all unused/freed memory to the OS when the UI closes.

In main.rs, we clear the catalog_flavors cache from memory when no longer needed, and load on demand.

In mod.rs, we call reclaim_memory_if_idle to immediately release decompressor and download buffers back to the OS. 

Complete build and packaging with decky-cli tested, confirm memory issues resolved