### PR TITLE
Redo entire GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,12 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-26.04
+    timeout-minutes: 30
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,13 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # 6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           check-latest: true
           package-manager-cache: false
       - name: Set up PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 9
           cache: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,40 +24,31 @@ jobs:
           cache: false
           run_install: true
       - name: Build frontend
-        run: pnpm build
-      - name: Extract project name
-        id: extract-project-name
-        run: echo "project_name=$(jq -r '.name' plugin.json)" >> $GITHUB_OUTPUT
-      - name: Extract project version
-        id: extract-project-version
-        run: echo "project_version=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
-      - name: Create directory
-        run: mkdir -p "${{ steps.extract-project-name.outputs.project_name }}/bin"
-      - name: Copy frontend files
-        run: cp -r dist "${{ steps.extract-project-name.outputs.project_name }}"
-      - name: Set up Rust
-        run: rustup update
-      - name: Extract backend binary name
-        id: extract-backend-binary-name
-        run: echo "binary_name=$(awk -F ' = ' '$1 == "name" {print $2}' backend/Cargo.toml | tr -d '\"')" >> $GITHUB_OUTPUT
+        id: metadata
+        run: |
+          pnpm build
+          project_name=$(jq -r '.name' plugin.json)
+          project_version=$(jq -r '.version' package.json)
+          echo "project_name=$project_name" >> $GITHUB_OUTPUT
+          echo "project_version=$project_version" >> $GITHUB_OUTPUT
+          mkdir -p "$project_name/bin"
+          cp -r dist "$project_name"
       - name: Build backend
-        run: cargo build --release --manifest-path backend/Cargo.toml
-      - name: Copy backend binary
         run: |
-          chmod +x backend/target/release/${{ steps.extract-backend-binary-name.outputs.binary_name }}
-          cp backend/target/release/${{ steps.extract-backend-binary-name.outputs.binary_name }} "${{ steps.extract-project-name.outputs.project_name }}/bin/backend"
-      - name: Copy additional files
-        run: |
-          cp main.py "${{ steps.extract-project-name.outputs.project_name }}"
-          cp LICENSE "${{ steps.extract-project-name.outputs.project_name }}"
-          cp README.md "${{ steps.extract-project-name.outputs.project_name }}"
-          cp package.json "${{ steps.extract-project-name.outputs.project_name }}"
-          cp plugin.json "${{ steps.extract-project-name.outputs.project_name }}"
-          mkdir build
-          cp -r "${{ steps.extract-project-name.outputs.project_name }}" build
+          binary_name=$(awk -F ' = ' '$1 == "name" {print $2}' backend/Cargo.toml | tr -d '\"')
+          cargo build --release --manifest-path backend/Cargo.toml
+          chmod +x backend/target/release/$binary_name
+          cp backend/target/release/$binary_name "${{ steps.metadata.outputs.project_name }}/bin/backend"
+          cp main.py "${{ steps.metadata.outputs.project_name }}"
+          cp LICENSE "${{ steps.metadata.outputs.project_name }}"
+          cp README.md "${{ steps.metadata.outputs.project_name }}"
+          cp package.json "${{ steps.metadata.outputs.project_name }}"
+          cp plugin.json "${{ steps.metadata.outputs.project_name }}"
+          mkdir -p build
+          cp -r "${{ steps.metadata.outputs.project_name }}" build
       - name: Upload Artifacts to GitHub
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: "${{ steps.extract-project-name.outputs.project_name }}-${{ steps.extract-project-version.outputs.project_version }}"
+          name: "${{ steps.metadata.outputs.project_name }}-${{ steps.metadata.outputs.project_version }}"
           path: "build"
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
           version: 9
           cache: false
           run_install: true
+      - name: Set up Rust
+        run: rustup update
       - name: Build frontend
         id: metadata
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,63 +1,51 @@
 name: Build and Package
-
 on:
   push:
     branches:
       - main
-
 jobs:
   build:
-    runs-on: ubuntu-latest
-
+    runs-on: ubuntu-26.04
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          node-version: 18
-
-      - name: Setup PNPM@9
+          persist-credentials: false
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # 6.4.0
+        with:
+          node-version: 24
+          check-latest: true
+          package-manager-cache: false
+      - name: Set up PNPM
         uses: pnpm/action-setup@v4
         with:
           version: 9
-  
-      - name: Install frontend dependencies
-        run: pnpm i
-
+          cache: false
+          run_install: true
       - name: Build frontend
         run: pnpm build
-
       - name: Extract project name
         id: extract-project-name
         run: echo "project_name=$(jq -r '.name' plugin.json)" >> $GITHUB_OUTPUT
-
       - name: Extract project version
         id: extract-project-version
         run: echo "project_version=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
-
       - name: Create directory
         run: mkdir -p "${{ steps.extract-project-name.outputs.project_name }}/bin"
-
       - name: Copy frontend files
         run: cp -r dist "${{ steps.extract-project-name.outputs.project_name }}"
-
-      - name: Setup Rust
+      - name: Set up Rust
         run: rustup update
-
       - name: Extract backend binary name
         id: extract-backend-binary-name
         run: echo "binary_name=$(awk -F ' = ' '$1 == "name" {print $2}' backend/Cargo.toml | tr -d '\"')" >> $GITHUB_OUTPUT
-
       - name: Build backend
         run: cargo build --release --manifest-path backend/Cargo.toml
-
       - name: Copy backend binary
         run: |
           chmod +x backend/target/release/${{ steps.extract-backend-binary-name.outputs.binary_name }}
           cp backend/target/release/${{ steps.extract-backend-binary-name.outputs.binary_name }} "${{ steps.extract-project-name.outputs.project_name }}/bin/backend"
-
       - name: Copy additional files
         run: |
           cp main.py "${{ steps.extract-project-name.outputs.project_name }}"
@@ -67,9 +55,9 @@ jobs:
           cp plugin.json "${{ steps.extract-project-name.outputs.project_name }}"
           mkdir build
           cp -r "${{ steps.extract-project-name.outputs.project_name }}" build
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+      - name: Upload Artifacts to GitHub
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "${{ steps.extract-project-name.outputs.project_name }}-${{ steps.extract-project-version.outputs.project_version }}"
           path: "build"
+          if-no-files-found: error

--- a/.github/workflows/decky-cli-build.yml
+++ b/.github/workflows/decky-cli-build.yml
@@ -12,13 +12,13 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # 6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           check-latest: true
           package-manager-cache: false
       - name: Set up PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 9
           cache: false

--- a/.github/workflows/decky-cli-build.yml
+++ b/.github/workflows/decky-cli-build.yml
@@ -3,9 +3,12 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   decky-cli-build:
     runs-on: ubuntu-26.04
+    timeout-minutes: 30
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/decky-cli-build.yml
+++ b/.github/workflows/decky-cli-build.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           version: 9
           cache: false
-          run_install: true
+          run_install: false
       - name: Decky CLI Build
         run: |
           mkdir $(pwd)/cli

--- a/.github/workflows/decky-cli-build.yml
+++ b/.github/workflows/decky-cli-build.yml
@@ -1,28 +1,28 @@
 name: Decky CLI Build and Package
-
 on:
   push:
     branches:
       - main
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
+  decky-cli-build:
+    runs-on: ubuntu-26.04
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          node-version: 18
-
-      - name: Setup PNPM@9
+          persist-credentials: false
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # 6.4.0
+        with:
+          node-version: 24
+          check-latest: true
+          package-manager-cache: false
+      - name: Set up PNPM
         uses: pnpm/action-setup@v4
         with:
           version: 9
-
+          cache: false
+          run_install: true
       - name: Decky CLI Build
         run: |
           mkdir $(pwd)/cli
@@ -30,9 +30,9 @@ jobs:
           chmod +x $(pwd)/cli/decky
           $(pwd)/cli/decky plugin build $(pwd)
           unzip "out/Wine Cellar.zip" -d "out/Wine Cellar"
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+      - name: Upload Artifacts to GitHub
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: decky-wine-cellar
           path: out/Wine Cellar/*
+          if-no-files-found: error


### PR DESCRIPTION
Mostly yoinked from [BaseProject](https://github.com/florianreuth/BaseProject/blob/main/.github/workflows/build.yml) except this is about node and pnpm.

1. Fully redone the entire workflow system to improve security and become more reliable,
2. Compresses both frontend and backend actions into singular steps,
3. Automatically runs "pnpm install" at the "Set up PNPM" section.

*Warning before merging: [GitHub has deprecated Node.Js 23 and older](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners) meaning 24 or later is needed to stay supported. PNPM 9 currently is supported at time of making this pull request.*